### PR TITLE
Add note about avoiding credential leaks in BBR scripts

### DIFF
--- a/bbr-devguide.html.md.erb
+++ b/bbr-devguide.html.md.erb
@@ -122,6 +122,12 @@ For more information, see [Metadata Script](#metadata).
 
 The `stdout` and `stderr` streams are captured and sent to the operator who invokes the backup and restore.
 
+<p class="note">
+  <strong>Important</strong>: Release authors should avoid printing sensitive information to <code>stdout</code> or <code>stderr</code>.
+  BBR will print any output from the scripts in case of failure. Make sure your script is not printing any sensitive data, like credentials.
+  In particular, if you're using <code>set -x</code> in your script, make sure to add <code>set +x</code> before you use any credentials.
+</p>
+
 ## <a id='backup-workflow'></a>Backup Workflow
 
 ### <a id='pre-backup-lock'></a>Pre-Backup-Lock


### PR DESCRIPTION
Hi! We have seen some differences in our bbr docs between the version on pivotal.io: https://docs.pivotal.io/bbr/ and the version on cloudfoundry: https://docs.cloudfoundry.org/bbr/

Both of them should pull from the same repo. How could we make sure our changes are applied to both?

Thanks,
@gcapizzi && Chunyi