### PR TITLE
Add a paragraph about enabling replication to the external blobstores page

### DIFF
--- a/external-blobstores.html.md.erb
+++ b/external-blobstores.html.md.erb
@@ -4,7 +4,7 @@ owner: BBR
 ---
 
 This topic describes how to configure an external blobstore so that it can be backed up
-and restored by BOSH Backup and Restore (BBR). 
+and restored by BOSH Backup and Restore (BBR).
 
 If your external blobstore is hosted on Amazon S3 or a compatible storage solution that supports S3 versioning
 and AWS Signature Version 4,
@@ -16,7 +16,7 @@ and, if necessary, how to prepare the backup artifact for restore.
 The backup artifact only contains references to versions of blobs, not the actual files.
 As a consequence, **restores only work if the original bucket still exists**.
 If the bucket gets deleted, all its versions are deleted with it
-and you cannot restore it unless you have a replica. 
+and you cannot restore it unless you have a replica.
 For how to restore from a replica, see [Restore from Replicas](#restore-from-replicas) below.
 
 ## <a id="enable-versioning"></a> Enable Versioning on Your External Blobstore
@@ -28,22 +28,41 @@ To enable versioning of Amazon S3 buckets, do the following:
 
 1. Follow the instructions in the Amazon S3 documentation, [How Do I Enable or Suspend Versioning for an S3 Bucket?]
 (https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html)
-to enable versioning. 
+to enable versioning.
 
 2. If your blobstore buckets are not empty, run the following command on each one of them, using the
 [AWS CLI](https://aws.amazon.com/cli/):
 
     <code>aws s3 cp s3://BUCKET-NAME/ s3://BUCKET-NAME/ --recursive --metadata bump=true</code><br>
 
-    For example, 
+    For example,
     <pre class="terminal">
     $ aws s3 cp s3://my-bucket/ s3://my-bucket/ --recursive --metadata bump=true
     </pre>
- 
-    This ensures that each file in your buckets has a valid version ID.
 
-<p class="note"><strong>Note</strong>: If your blobstore uses S3-compatible buckets not from Amazon, 
+    This ensures that each file in your buckets has a valid version identifier.
+
+<p class="note"><strong>Note</strong>: If your blobstore uses S3-compatible buckets not from Amazon,
 see the documentation for that storage provider to enable versioning.</p>
+
+## <a id="enable-replication"></a> Enable Replication on Your External Blobstore
+
+BBR will **not** download your blobs to the backup artifact when performing a
+backup. Instead, it will take note of the _current version identifier_ of each
+one of your blobs, and store those in the artifact.
+
+When restoring, BBR will revert your blobs to the original versions using the
+version identifiers stored in the artifact. This will only work **if the
+original bucket still exists**, as those versions are stored in the bucket,
+while the backup artifact only contains identifiers.
+
+If the bucket gets deleted, all its versions are deleted with it, and you will
+not be able to restore it. To prevent this from happening, you can set up
+[Cross-Region Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html).
+Replication results in buckets that are identical to the original ones,
+including their version identifiers. This allows you to perform restores from
+the replicas, in case your original buckets are lost. For how to restore from a
+replica, see [Restore from Replicas](#restore-from-replicas) below.
 
 ## <a id="enable-backup-and-restore"></a> Enable Backup and Restore of External Blobstores
 
@@ -64,7 +83,7 @@ This procedure describes how to do this if you are using ops files to customize 
        before <code>enable-backup-restore-s3.yml</code>.
        See <a href="cf-backup.html#order">Apply Ops Files in the Correct Order</a>.</p>
 
-If you do not use [cf-deployment](https://github.com/cloudfoundry/cf-deployment) and ops files, 
+If you do not use [cf-deployment](https://github.com/cloudfoundry/cf-deployment) and ops files,
 you can still set up your Cloud Foundry deployment to use BBR.
 Examine the contents of the ops file,
 and use it as a guide to customize your deployment manifest directly.
@@ -100,15 +119,14 @@ destination buckets.
 
 ### <a id="restore-from-replicas"></a> Restore from Replicas
 
-To protect yourself from losing your blobstore buckets,
-set up [Cross-Region Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html).
-Replication results in buckets that are identical to the original ones, including their version IDs.
-This allows you to perform restores from the replicas, in case your original buckets are lost.
+To protect yourself from losing your blobstore buckets, you should [enable
+replication](#enable-replication). This will allow you to perform restores from
+the replicas, in case your original buckets are lost.
 
 If you need to restore from replicas, you must modify the backup artifacts to point to the replicas
-before beginning a restore. 
+before beginning a restore.
 
-To modify the backup artifacts, do the following: 
+To modify the backup artifacts, do the following:
 
 1. Change into the backup artifact directory.
 
@@ -133,7 +151,7 @@ To modify the backup artifacts, do the following:
 
     <code>tar cvf BLOBSTORE-ARTIFACT.tar blobstore.json</code>
 
-    For example, 
+    For example,
 
     <pre class="terminal">$ tar cvf backup-restore-0-s3-versioned-blobstore-backup-restorer.tar blobstore.json</pre>
 

--- a/external-blobstores.html.md.erb
+++ b/external-blobstores.html.md.erb
@@ -26,9 +26,12 @@ and in S3-compatible buckets that are versioned and support AWS Signature Versio
 
 To enable versioning of Amazon S3 buckets, do the following:
 
-1. Follow the instructions in the Amazon S3 documentation, [How Do I Enable or Suspend Versioning for an S3 Bucket?]
-(https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html)
-to enable versioning.
+1. Follow the instructions in the Amazon S3 documentation, [How Do I Enable or
+Suspend Versioning for an S3
+Bucket?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/enable-versioning.html)
+to enable versioning. If you prefer to use the `aws` CLI, you can make use of
+the [`put-bucket-versioning`
+command](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-versioning.html).
 
 2. If your blobstore buckets are not empty, run the following command on each one of them, using the
 [AWS CLI](https://aws.amazon.com/cli/):
@@ -58,7 +61,11 @@ while the backup artifact only contains identifiers.
 
 If the bucket gets deleted, all its versions are deleted with it, and you will
 not be able to restore it. To prevent this from happening, you can set up
-[Cross-Region Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html).
+[Cross-Region
+Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (see the
+[`put-bucket-replication`
+command](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-replication.html)
+if you prefer to use the `aws` CLI).
 Replication results in buckets that are identical to the original ones,
 including their version identifiers. This allows you to perform restores from
 the replicas, in case your original buckets are lost. For how to restore from a


### PR DESCRIPTION
This tries to make clearer that the backup artifact does not contain actual files for external blobstores, and thus it is important to enable replication. We've also added references to AWS CLI commands useful to set up versioning and replication.