### PR TITLE
Correct anchor link to good-practices

### DIFF
--- a/backup.html.md.erb
+++ b/backup.html.md.erb
@@ -70,7 +70,7 @@ Follow these steps to verify that your BOSH Director is reachable and can be bac
     </pre>
 
 5. If the backup command completes successfully,
-   follow the steps in [Good Practices for Managing Your Backup Artifact](#good-practice) below.
+   follow the steps in [Good Practices for Managing Your Backup Artifact](#good-practices) below.
 
 6. If the backup command fails, do the following: 
    + Run the command again adding the `--debug` flag to enable debug logs.<br>


### PR DESCRIPTION
The anchor link should be pluralized.