### PR TITLE
Update cf-backup and external-blobstore-backup pages

### DIFF
--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -1,23 +1,16 @@
 ---
-title: Configuring Cloud Foundry for BOSH Backup and Restore (Experimental)
+title: Configuring Cloud Foundry for BOSH Backup and Restore
 owner: BBR
 ---
 
-This topic describes the configuration you need for your Cloud Foundry deployment 
+This topic describes the configuration you need for your Cloud Foundry deployment
 to work with BOSH Backup and Restore (BBR).
 
-This topic assumes that you are using [cf-deployment](https://github.com/cloudfoundry/cf-deployment) 
+This topic assumes that you are using [cf-deployment](https://github.com/cloudfoundry/cf-deployment)
 with ops files for your Cloud Foundry deployment.
 
-<p class="note warning">
-  <strong>WARNING</strong>: The <code>enable-backup-restore.yml</code>, 
-  <code>enable-backup-restore-s3.yml</code>, <code>enable-nfs-broker-backup.yml</code>, 
-  and <code>enable-backup-restore-credhub.yml</code> ops files are currently 
-  experimental and should be used with caution.
-</p>
-
-If you do not use ops files for customization, 
-you can still customize your Cloud Foundry to use BBR. 
+If you do not use ops files for customization,
+you can still customize your Cloud Foundry to use BBR.
 Examine the contents of the ops files on this page,
 and use them as a guide to customize your deployment manifest directly.
 
@@ -38,59 +31,74 @@ and use them as a guide to customize your deployment manifest directly.
 
 ## <a id='configure-cf'></a>Supported CF Configurations
 
-Unless otherwise stated, the described functionality is available in `cf-deployment` v1.3.0 and later.
+To enable backup and restore for your `cf-deployment`, deploy it with the [`enable-backup-restore.yml`](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore.yml) ops file. This will enable BBR backup and restore for all the default CF components.
 
-Your CF deployment is compatible with BBR if the following requirements are met:
-
-  + An `enable-backup-restore.yml` ops file is deployed.
-  + An internal MySQL database or a <a href="cf-backup.html#supported-external-databases">supported external database</a> is present.
-  + An internal WebDAV/NFS blobstore is present.
-  + No optional components, such as a runtime CredHub store or an NFS volume service, are deployed.
-
-If your CF deployment does not fit the above requirements, 
-then you might be able to use BBR by applying additional ops files as described in the table below
-and by using a later version of `cf-deployment`. 
-
+To enable BBR backup and restore for different configurations you must in addition use the appropriate backup and restore ops files from this table:
 
 <table class="nice">
   <tr>
-    <th>To use BBR with…</th>
-    <th>Use this ops file…</th>
-    <th>And…</th>
+    <th>Configuration</th>
+    <th>Configuration Ops File</th>
+    <th>Backup and Restore Ops File</th>
   </tr>
   <tr>
     <td>
-      An external blobstore hosted on Amazon S3 or a compatible storage solution that supports S3 versioning
-      and AWS Signature Version 4<br>
+      A versioned S3-compatible external blobstore. For instructions, see <a href="external-blobstores.html">Backup and Restore with External Blobstores</a>.
+    </td>
+    <td>
       <code>use-s3-blobstore.yml</code>
     </td>
     <td>
-      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/experimental/enable-backup-restore-s3.yml">
-        <code>enable-backup-restore-s3.yml</code></a>
-    </td>
-    <td>
-      <code>cf-deployment</code> v1.4.0 or later.<br>
-      For instructions, see <a href="external-blobstores.html">Backup and Restore with External Blobstores</a>.
+      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore-s3-versioned.yml">
+        <code>enable-backup-restore-s3-versioned.yml</code></a>
     </td>
   </tr>
   <tr>
     <td>
-      An NFS volume service component<br>
+      An unversioned S3-compatible external blobstore. For instructions, see <a href="external-blobstores.html">Backup and Restore with External Blobstores</a>.
+    </td>
+    <td>
+      <code>use-s3-blobstore.yml</code>
+    </td>
+    <td>
+      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore-s3-unversioned.yml">
+        <code>enable-backup-restore-s3-unversioned.yml</code></a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      A <a href="#supported-external-databases">supported external database</a>
+    </td>
+    <td>
+      <code>use-external-dbs.yml</code>
+    </td>
+    <td>
+      No BBR ops file required
+    </td>
+  </tr>
+  <tr>
+    <td>
+      An NFS broker and volume driver for volume support
+    </td>
+    <td>
       <code>enable-nfs-volume-service.yml</code>
     </td>
     <td>
-      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/experimental/enable-nfs-broker-backup.yml">
-      <code>enable-nfs-broker-backup.yml</code></a>
+      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore-nfs-broker.yml">
+      <code>enable-backup-restore-nfs-broker.yml</code></a>
     </td>
-    <td><em>n/a</em></td>
   </tr>
   <tr>
-    <td>CredHub data store component<br> <code>secure-service-credentials.yml</code></td>
     <td>
-      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/experimental/enable-backup-restore-credhub.yml">
+      Use CredHub for service credentials (experimental)<br>
+    </td>
+    <td>
+      <code>secure-service-credentials.yml</code>
+    </td>
+    <td>
+      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore-credhub.yml">
       <code>enable-backup-restore-credhub.yml</code></a>
     </td>
-    <td><em>n/a</em></td>
   </tr>
 </table>
 
@@ -121,24 +129,27 @@ but do not apply <code>enable-backup-restore.yml</code> <em>before</em> <code>us
 1. `use-s3-blobstore.yml`
 
 1. `use-external-dbs.yml`
- 
+
+1. `enable-nfs-volume-service.yml`
+
+1. `secure-service-credentials.yml`
+
 1. `enable-backup-restore.yml`
 
-1. `enable-backup-restore-s3.yml`
+1. `enable-backup-restore-s3-versioned.yml` or `enable-backup-restore-s3-unversioned.yml`
 
-1. `enable-nfs-broker-backup.yml`
+1. `enable-backup-restore-nfs-broker.yml`
 
 1. `enable-backup-restore-credhub.yml`
-
 
 ## <a id='process'></a> Next Steps
 
 After Cloud Foundry is configured to be compatible with BBR,
-it can be backed up and restored. 
+it can be backed up and restored.
 
 Follow the procedures in [Back Up a BOSH Deployment](backup.html#back-up-deployment)
 and [Restore a BOSH Deployment](restore.html#restore-deployment).
 
 At minimum, run the pre-backup check against your Cloud Foundry deployment.
-Follow the first two steps of [Back Up a BOSH Deployment](./backup.html#back-up-deployment). 
+Follow the first two steps of [Back Up a BOSH Deployment](./backup.html#back-up-deployment).
 This lists the scripts that run during a backup and the order that they are applied in.

--- a/external-blobstores.html.md.erb
+++ b/external-blobstores.html.md.erb
@@ -19,27 +19,100 @@ owner: BBR
 }
 </style>
 
-This topic describes configuring an external blobstore so that it can be backed up and restored by BOSH Backup and Restore (BBR). 
-
-If your external blobstore is hosted on Amazon S3 or a compatible storage solution that supports S3 versioning
-and AWS Signature Version 4,
-it can be backed up and restored by BBR.
+This topic describes configuring an external blobstore so that it can be backed up and restored by BOSH Backup and Restore (BBR).
 
 This topic also describes the different restore scenarios for external blobstores and, if necessary, how to prepare the backup artifact for restore.
 
-The backup artifact only contains references to versions of blobs, not the actual files.
-As a consequence, **restores only work if the original bucket still exists**.
-If the bucket gets deleted, all its versions are deleted with it
-and you cannot restore it unless you have a replica. 
-For how to restore from a replica, see [Restore from Replicas](#restore-from-replicas) below.
+BBR supports the backup and restore of blobstores stored in Amazon S3 buckets and in S3-compatible storage solutions.
+
+The necessary configuration and supported restore scenarios differ depending on whether your blobstore is versioned or not - for specific details see the sections below.
+
+## <a id="s3-unversioned"></a> S3-Compatible Unversioned Blobstores
+
+External blobstores are backed up by copying blobs from live buckets to specified backup buckets. The unversioned backup-restorer uses the blobstore's copy functionality to transfer blobs between the buckets to avoid transferring and storing the blobs on your instances.
+
+**Restore only works if the backup buckets still exist**. For this reason, we recommend that either the backup buckets or copies of them should be in a different region to the live buckets.
+
+### <a id="enable-backup-and-restore-s3-unversioned"></a> Enable Backup and Restore of Your Unversioned S3-Compatible Blobstore
+
+To back up a Cloud Foundry deployment that uses an unversioned S3-compatible external blobstore,
+you must colocate the `s3-unversioned-blobstore-backup-restorer` job from [`backup-and-restore-sdk-release`](https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/tree/master) as part of your deployment.
+
+1. Verify that your blobstore is one of the following:
+   + Amazon S3 buckets
+   + S3-compatible buckets with support for AWS Signature Version 4.
+
+       <p class="note"><strong>Note</strong>: If your S3-compatible blobstore uses a custom CA certificate, refer to <a href="https://bosh.io/docs/trusted-certs.html">Configuring Trusted Certificates</a> in the <a href="https://bosh.io/docs">BOSH documentation</a>.
+       BBR automatically makes use of your configured trusted certificates.</p>
+
+1. Create backup buckets for droplets, packages and buildpacks. We recommend that either the backup buckets or copies of them should be in a different region to the live buckets.
+
+1. Include the `enable-backup-restore-s3-unversioned.yml` ops file in your deployment.
+
+
+    Set the variables specified in [vars-enable-backup-restore-s3-unversioned.yml](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-s3-unversioned.yml) to configure your backup bucket locations.
+
+
+      <p class="note"><strong>Note</strong>: Apply <code>enable-backup-restore.yml</code> and <code>use-s3-blobstore.yml</code>
+         before <code>enable-backup-restore-s3-unversioned.yml</code>.
+         See <a href="cf-backup.html#order">Apply Ops Files in the Correct Order</a>.</p>
+
+
+    If you do not use [cf-deployment](https://github.com/cloudfoundry/cf-deployment) and ops files,
+    you can still set up your Cloud Foundry deployment to use BBR.
+    Examine the contents of the ops file,
+    and use it as a guide to customize your deployment manifest directly.
+
+
+### <a id="s3-unversioned-supported-restore-scenarios"></a> Supported Restore Scenarios For Your Unversioned S3-Compatible Blobstore
+
+The restore process will copy blobs from a directory in the backup bucket to the live buckets (droplets, packages and buildpacks) in use by the CF deployment you are restoring into.
+
+If your original backup buckets are lost but you are restoring from copies, ensure that the variables listed in [vars-enable-backup-restore-s3-unversioned.yml](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/example-vars-files/vars-enable-backup-restore-s3-unversioned.yml) point to the copies.
 
 <p class="note warning">
-  <strong>WARNING</strong>: The <code>blobstore-backup-restorer</code> in 
-  <a href="https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/releases">backup-and-restore-sdk</a> 
+  <strong>WARNING</strong>: Restoring to an unversioned bucket will overwite blobs with the backed up copies of those blobs.
+  BBR will only modify the blobs that were copied to the backup bucket. Any other blobs will not be affected.
+</p>
+
+## <a id="s3-versioned"></a> S3-Compatible Versioned Blobstores
+The versioned backup-restorer only supports S3-compatible buckets that are versioned and support AWS Signature Version 4. For more details about enabling versioning on your blobstore, see [enable versioning](#enable-s3-versioning).
+
+External blobstores are backed up by storing the current version of each blob, not the actual files. Those versions will be set to be the current versions at restore time. This makes backups and restores faster, but also means that **restores only work if the original bucket still exists**.
+
+If the bucket gets deleted, all its versions are deleted with it and you cannot restore it unless you have a replica. For how to restore from a replica, see [Restore from Replicas](#s3-versioned-restore-from-replicas) below.
+
+<p class="note warning">
+  <strong>WARNING</strong>: The <code>s3-versioned-blobstore-backup-restorer</code> in
+  <a href="https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/releases">backup-and-restore-sdk</a>
   v1.5.1 and earlier does not support the backup and restore of an AWS S3 blobstore with individual blobs greater than 5GB.
 </p>
 
-## <a id="enable-versioning"></a> Enable Versioning on Your External Blobstore
+### <a id="enable-backup-and-restore-s3-versioned"></a> Enable Backup and Restore of Your Versioned S3-Compatible Blobstore
+
+To back up a Cloud Foundry deployment that uses an external blobstore,
+you must colocate the `s3-versioned-blobstore-backup-restorer` job from [`backup-and-restore-sdk-release`](https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/tree/master) as part of your deployment.
+
+1. Verify that your blobstore is one of the following:
+   + Amazon S3 buckets with versioning enabled.
+     See [Enable Versioning on Your S3-Compatible Blobstore](#enable-s3-versioning) above.
+   + S3-compatible buckets with versioning enabled and support for AWS Signature Version 4.
+
+       <p class="note"><strong>Note</strong>: If your S3-compatible blobstore uses a custom CA certificate, refer to <a href="https://bosh.io/docs/trusted-certs.html">Configuring Trusted Certificates</a> in the <a href="https://bosh.io/docs">BOSH documentation</a>.
+BBR automatically makes use of your configured trusted certificates.</p>
+
+2. Include the `enable-backup-restore-s3-versioned.yml` ops file in your deployment.
+
+    <p class="note"><strong>Note</strong>: Apply <code>enable-backup-restore.yml</code> and <code>use-s3-blobstore.yml</code>
+       before <code>enable-backup-restore-s3-versioned.yml</code>.
+       See <a href="cf-backup.html#order">Apply Ops Files in the Correct Order</a>.</p>
+
+    If you do not use [cf-deployment](https://github.com/cloudfoundry/cf-deployment) and ops files,
+    you can still set up your Cloud Foundry deployment to use BBR.
+    Examine the contents of the ops file,
+    and use it as a guide to customize your deployment manifest directly.
+
+### <a id="enable-s3-versioning"></a> Enable Versioning on Your S3-Compatible Blobstore
 
 BBR only supports the backup and restore of blobstores stored in versioned, Amazon S3 buckets
 and in S3-compatible buckets that are versioned and support AWS Signature Version 4.
@@ -53,21 +126,22 @@ Follow the instructions in the Amazon S3 documentation, [How Do I Enable or Susp
 
     <code>aws s3 cp s3://BUCKET-NAME/ s3://BUCKET-NAME/ --recursive --metadata bump=true</code><br>
 
-    For example, 
+    For example,
     <pre class="terminal">
     $ aws s3 cp s3://my-bucket/ s3://my-bucket/ --recursive --metadata bump=true
     </pre>
- 
+
     This ensures that each file in your buckets has a valid version ID.
 
-3. After enabling versioning, you have a current version and zero or more non-current versions for each object. 
-We recommend setting a retention policy on your buckets to delete old non-current versions and minimize storage costs. 
-See the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex6">AWS documentation</a>.</p>
+3. After enabling versioning, you have a current version and zero or more non-current versions for each object.
+We recommend setting a retention policy on your buckets to delete old non-current versions and minimize storage costs.
+See the <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/lifecycle-configuration-examples.html#lifecycle-config-conceptual-ex6">AWS documentation</a>.
 
-<p class="note"><strong>Note</strong>: If your blobstore uses S3-compatible buckets not from Amazon, 
-see the documentation for that storage provider to enable versioning.</p>
+<p class="note">
+  <strong>Note</strong>: If your blobstore uses S3-compatible buckets not from Amazon, see the documentation for that storage provider to enable versioning.
+</p>
 
-## <a id="enable-replication"></a> Enable Replication on Your External Blobstore
+### <a id="enable-s3-versioned-replication"></a> Enable Replication on Your Versioned S3-Compatible Blobstore
 
 BBR does not download your blobs to the backup artifact when performing a backup. Instead, BBR notes the _current version identifier_ of each blob and stores the identifiers in the artifact.
 
@@ -75,71 +149,49 @@ When restoring, BBR reverts your blobs to the original versions using the versio
 
 If the bucket is deleted, all its versions are deleted with it, and you cannot restore using it. To prevent this from happening, set up [Cross-Region Replication](https://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html). See the [`put-bucket-replication` command](https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-replication.html) if you prefer to use the AWS CLI.
 
-Replication results in buckets that are identical to the original ones, including their version identifiers. This allows you to perform restores from the replicas, in case your original buckets are lost. To restore from a replica, see [Restore from Replicas](#restore-from-replicas) below.
+Replication results in buckets that are identical to the original ones, including their version identifiers. This allows you to perform restores from the replicas, in case your original buckets are lost. To restore from a replica, see [Restore from Replicas](#s3-versioned-restore-from-replicas) below.
 
-## <a id="enable-backup-and-restore"></a> Enable Backup and Restore of External Blobstores
-
-To back up a Cloud Foundry deployment that uses an external blobstore,
-you must colocate the `s3-versioned-blobstore-backup-restorer` job from [`backup-and-restore-sdk-release`](https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release/tree/master) as part of your deployment.
-
-This procedure describes how to do this if you are using ops files to customize your deployment:
-
-1. Verify that your blobstore is one of the following:
-   + Amazon S3 buckets with versioning enabled.
-     See [Enable Versioning on Your External Blobstore](#enable-versioning) above.
-   + S3-compatible buckets with versioning enabled and support for AWS Signature Version 4.
-
-       <p class="note"><strong>Note</strong>: If your S3-compatible blobstore uses a custom CA certificate, refer to <a href="https://bosh.io/docs/trusted-certs.html">Configuring Trusted Certificates</a> in the <a href="https://bosh.io/docs">BOSH documentation</a>.
-BBR automatically makes use of your configured trusted certificates.</p>
-
-2. Include the `enable-backup-restore-s3.yml` ops file in your deployment.
-
-    <p class="note"><strong>Note</strong>: Apply <code>enable-backup-restore.yml</code> and <code>use-s3-blobstore.yml</code>
-       before <code>enable-backup-restore-s3.yml</code>.
-       See <a href="cf-backup.html#order">Apply Ops Files in the Correct Order</a>.</p>
-
-If you do not use [cf-deployment](https://github.com/cloudfoundry/cf-deployment) and ops files, 
-you can still set up your Cloud Foundry deployment to use BBR.
-Examine the contents of the ops file,
-and use it as a guide to customize your deployment manifest directly.
-
-## <a id="supported-restore-scenarios"></a> Supported Restore Scenarios
+### <a id="s3-versioned-supported-restore-scenarios"></a> Supported Restore Scenarios For Your Versioned S3-Compatible Blobstore
 
 There are three distinct restore scenarios:
 
-+ [In-Place Restore](#in-place-restore)
-+ [Restore to New Buckets](#restore-to-new-buckets)
-+ [Restore from Replicas](#restore-from-replicas)
++ [In-Place Restore](#s3-versioned-in-place-restore)
++ [Restore to New Buckets](#s3-versioned-restore-to-new-buckets)
++ [Restore from Replicas](#s3-versioned-restore-from-replicas)
 
 Make sure that you understand which scenario applies to you before beginning a restore.
 
-### <a id="in-place-restore"></a> In-Place Restore
+<p class="note">
+  When restoring to a bucket, BBR will only modify blobs that are recorded in the backup artifact. Any other blobs will not be affected.
+</p>
+
+#### <a id="s3-versioned-in-place-restore"></a> In-Place Restore
 When backing up an
 external blobstore, the backup consists of a snapshot of the objects' IDs and versions.
 If your destination Cloud Foundry for a restore uses the original buckets of the backed-up Cloud Foundry,
 that is, you are doing an in-place restore,
 then, during a restore, those versions are retrieved and set to be the current versions in the buckets.
 
-### <a id="restore-to-new-buckets"></a> Restore to New Buckets
+#### <a id="s3-versioned-restore-to-new-buckets"></a> Restore to New Buckets
 
 If your destination Cloud Foundry for a restore uses different buckets,
 then you can also restore into those buckets, if the original buckets still exist.
 During restore, the original versions are copied from the original buckets to the destination buckets.
 
 The destination buckets must be versioned.
-For how to version an Amazon S3 blobstore, see [Enable Versioning on Your External Blobstore](#enable-versioning) above.
+For how to version an Amazon S3 blobstore, see [Enable Versioning on Your S3-Compatible Blobstore](#enable-s3-versioning) above.
 
 Before restoring, ensure that the `s3-versioned-blobstore-backup-restorer` job is configured to point to the
 destination buckets.
 
-### <a id="restore-from-replicas"></a> Restore from Replicas
+#### <a id="s3-versioned-restore-from-replicas"></a> Restore from Replicas
 
-To protect yourself from losing your blobstore buckets, you should [enable replication](#enable-replication). This will allow you to perform restores from the replicas, in case your original buckets are lost.
+To protect yourself from losing your blobstore buckets, you should [enable replication](#enable-s3-versioned-replication). This will allow you to perform restores from the replicas, in case your original buckets are lost.
 
 If you need to restore from replicas, you must modify the backup artifacts to point to the replicas
-before beginning a restore. 
+before beginning a restore.
 
-To modify the backup artifacts, do the following: 
+To modify the backup artifacts, do the following:
 
 1. Change into the backup artifact directory.
 
@@ -164,7 +216,7 @@ To modify the backup artifacts, do the following:
 
     <code>tar cvf BLOBSTORE-ARTIFACT.tar blobstore.json</code>
 
-    For example, 
+    For example,
 
     <pre class="terminal">$ tar cvf backup-restore-0-s3-versioned-blobstore-backup-restorer.tar blobstore.json</pre>
 


### PR DESCRIPTION
Hi!

We updated links to our backup and restore opsfiles in cf-deployment. In addition, this PR also adds documentation on a new opsfiles in cf-deployment `enable-backup-restore-s3-unversioned.yml`. 

Lets us know if there is anything unclear about this PR.

Cheers,
Chunyi && @MirahImage  