### PR TITLE
Fix tar command in restore from s3 replicas topic

### DIFF
--- a/external-blobstores.html.md.erb
+++ b/external-blobstores.html.md.erb
@@ -217,10 +217,10 @@ To modify the backup artifacts, do the following:
 
 6. Run the following command to recreate the archive:
 
-    <code>tar cvf BLOBSTORE-ARTIFACT.tar blobstore.json</code>
+    <code>tar cvf BLOBSTORE-ARTIFACT.tar ./blobstore.json</code>
 
     For example,
 
-    <pre class="terminal">$ tar cvf backup-restore-0-s3-versioned-blobstore-backup-restorer.tar blobstore.json</pre>
+    <pre class="terminal">$ tar cvf backup-restore-0-s3-versioned-blobstore-backup-restorer.tar ./blobstore.json</pre>
 
 The backup artifact is now ready to be restored from the replicated buckets.


### PR DESCRIPTION
Fixes issue where users following the steps would see `Backup is corrupted` error.

[#159134964](https://www.pivotaltracker.com/story/show/159134964)