### PR TITLE
Remove documentation about bbr cli exit code

### DIFF
--- a/logging.html.md.erb
+++ b/logging.html.md.erb
@@ -1,55 +1,9 @@
 ---
-title: BBR Exit Codes and Logging
+title: BBR Logging
 owner: BBR
 ---
 
-This topic provides information about the exit codes returned by BBR and BBR logging. Use this information when troubleshooting a failed backup or restore using BBR.
-
-## <a id='exit-codes'></a>Exit Codes
-
-The exit code returned by BBR indicates the status of the backup or restore. The following table matches exit codes to error messages.
-
-<table>
-<tr>
-<th>Value</th>
-<th>Error</th>
-</tr>
-<tr>
-<td>0</td>
-<td>Success</td>
-</tr>
-<tr>
-<td>1</td>
-<td>General failure</td>
-</tr>
-<tr>
-<td>4</td>
-<td>The pre-backup lock failed.</td>
-</tr>
-<tr>
-<td>8</td>
-<td>The post-backup unlock failed. Your BOSH deployment or BOSH Director may be in a bad state and require attention.</td>
-</tr>
-<tr>
-<td>16</td>
-<td>The cleanup failed. This is a non-fatal error indicating that the utility has been unable to clean up open BOSH SSH connections to the deployment VMs. Manual cleanup may be required to clear any hanging BOSH users and connections.</td>
-</tr>
-</table>
-
-If multiple failures occur, your exit code reflects a combination of values. Use bitwise AND to determine which failures occurred.
-
-For example, the exit code `5` indicates that the pre-backup lock failed and a general error occurred.
-
-To check that a bit is set, use bitwise AND, as demonstrated by the following example of exit code `20`:
-
-<pre class="highlight ruby"><code><span class="mi">20</span> <span class="o">&</span> <span class="mi">1</span>  <span class="o">==</span> <span class="mi">1</span>    <span class="c1"># false</span>
-<span class="mi">20</span> <span class="o">&</span> <span class="mi">4</span>  <span class="o">==</span> <span class="mi">4</span>    <span class="c1"># true; lock failed</span>
-<span class="mi">20</span> <span class="o">&</span> <span class="mi">8</span>  <span class="o">==</span> <span class="mi">8</span>    <span class="c1"># false</span>
-<span class="mi">20</span> <span class="o">&</span> <span class="mi">16</span> <span class="o">==</span> <span class="mi">16</span>   <span class="c1"># true; cleanup failed</span>
-</code>
-</pre>
-
-Exit code `20` indicates that the pre-backup lock failed and cleanup failed.
+This topic provides information about BBR logging. Use this information when troubleshooting a failed backup or restore using BBR.
 
 ## <a id='logging'></a>Logging
 


### PR DESCRIPTION
Hi!

The platform recovery team would like to stop documenting the bbr binary's exit code. We believe the information is confusing and not being used by our customer. This PR is related to [PR](https://github.com/pivotal-cf/docs-pcf-install/pull/492) which removes the same documentation from the closed-source PCF docs.

Thanks!
Chunyi

[#159593095]