### PR TITLE
Update blobstore documentation to include selective backups

### DIFF
--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -5,11 +5,11 @@ owner: BBR
 
 This topic describes the configuration you need for your Cloud Foundry (CF) deployment to work with BOSH Backup and Restore (BBR).
 
-This topic assumes that you are using 
-[cf-deployment](https://github.com/cloudfoundry/cf-deployment) with ops files 
+This topic assumes that you are using
+[cf-deployment](https://github.com/cloudfoundry/cf-deployment) with ops files
 for your Cloud Foundry deployment.
 
-If you do not use ops files for customization, you can still customize your 
+If you do not use ops files for customization, you can still customize your
 Cloud Foundry to use BBR. Examine the contents of the ops files on this page,
 and use them as a guide to customize your deployment manifest directly.
 
@@ -30,8 +30,8 @@ and use them as a guide to customize your deployment manifest directly.
 
 ## <a id='configure-cf'></a>Supported CF Configurations
 
-To enable backup and restore for your `cf-deployment`, deploy it with the 
-[enable-backup-restore.yml](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore.yml) ops file. This 
+To enable backup and restore for your `cf-deployment`, deploy it with the
+[enable-backup-restore.yml](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore.yml) ops file. This
 enables BBR backup and restore for default CF components.
 
 To enable BBR backup and restore for different configurations you must also use the appropriate backup and restore ops files as shown in this table:
@@ -101,18 +101,6 @@ To enable BBR backup and restore for different configurations you must also use 
       <code>enable-backup-restore-nfs-broker.yml</code></a>
     </td>
   </tr>
-  <tr>
-    <td>
-      Use CredHub for service credentials (Experimental)<br>
-    </td>
-    <td>
-      <code>secure-service-credentials.yml</code>
-    </td>
-    <td>
-      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore-credhub.yml">
-      <code>enable-backup-restore-credhub.yml</code></a>
-    </td>
-  </tr>
 </table>
 
 BBR can communicate with external blobstores and databases over TLS if they are configured accordingly.
@@ -133,30 +121,21 @@ The backup and restore SDK supports the following database versions:
 
 
 ## <a id="order"></a> Apply Ops Files in the Correct Order
-
-Select the ops files you need and apply them in the following order:
-
-<p class="note"><strong>Note</strong>: This is the <em>relative</em> order.
-You do not have to apply all ops files listed below and you can apply other ops files in between.<br>
-For example, you can apply an ops file between <code>use-external-dbs.yml</code> and <code>enable-backup-restore.yml</code>,
-but do not apply <code>enable-backup-restore.yml</code> <em>before</em> <code>use-external-dbs.yml</code>.
-</p>
+When enabling backup and restore for a component of `cf-deployment` you must ensure that you have the ops file for enabling backup and restore applied after you have applied the feature. For example if you configured your `cf-deployment` to use an S3 blobstore you would need to make sure that you apply the ops files in the following order:
 
 1. `use-s3-blobstore.yml`
+1. `enable-backup-restore-s3-unversioned.yml`
 
-1. `use-external-dbs.yml`
+Another example would be configuring your `cf-deployment` to use an external database and enabling backup restore for it.  In this case the relative is order is the following:
 
-1. `enable-nfs-volume-service.yml`
-
-1. `secure-service-credentials.yml`
-
+1. `use-external-db.yml`
 1. `enable-backup-restore.yml`
 
-1. `enable-backup-restore-s3-versioned.yml` or `enable-backup-restore-s3-unversioned.yml`
-
-1. `enable-backup-restore-nfs-broker.yml`
-
-1. `enable-backup-restore-credhub.yml`
+<p class="note">
+This is the <em>relative</em> order. You can apply other ops files in between.<br>
+For example, you can apply an ops file between <code>use-s3-blobstore.yml</code> and <code>enable-backup-restore-s3-unversioned.yml</code>,
+but do not apply <code>enable-backup-restore-s3-unversioned.yml</code> <em>before</em> <code>use-s3-blobstore.yml</code>.
+<p>
 
 ## <a id='process'></a> Next Steps
 

--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -80,6 +80,18 @@ To enable BBR backup and restore for different configurations you must also use 
   </tr>
   <tr>
     <td>
+      A GCS external blobstore. For instructions, see <a href="external-blobstores.html#gcs">Backup and Restore with External Blobstores</a>.
+    </td>
+    <td>
+      <code>use-gcs-blobstore.yml</code>
+    </td>
+    <td>
+      <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore-gcs.yml">
+        <code>enable-backup-restore-gcs.yml</code></a>
+    </td>
+  </tr>
+  <tr>
+    <td>
       A <a href="#supported-external-databases">supported external database</a>
     </td>
     <td>
@@ -120,7 +132,10 @@ The backup and restore SDK supports the following database versions:
 | Postgres | 9.6.x   |
 
 
-## <a id="order"></a> Apply Ops Files in the Correct Order
+### <a id='supported-blobstore-backup-configurations'></a>Supported Blobstore Backup Configurations
+
+
+### <a id="order"></a> Apply Ops Files in the Correct Order
 When enabling backup and restore for a component of `cf-deployment` you must ensure that you have the ops file for enabling backup and restore applied after you have applied the feature. For example if you configured your `cf-deployment` to use an S3 blobstore you would need to make sure that you apply the ops files in the following order:
 
 1. `use-s3-blobstore.yml`

--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -32,7 +32,7 @@ and use them as a guide to customize your deployment manifest directly.
 
 To enable backup and restore for your `cf-deployment`, deploy it with the
 [enable-backup-restore.yml](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/enable-backup-restore.yml) ops file. This
-enables BBR backup and restore for default CF components.
+enables BBR backup and restore for default CF components, including the internal blobstore.
 
 To enable BBR backup and restore for different configurations you must also use the appropriate backup and restore ops files as shown in this table:
 
@@ -132,8 +132,33 @@ The backup and restore SDK supports the following database versions:
 | Postgres | 9.6.x   |
 
 
-### <a id='supported-blobstore-backup-configurations'></a>Supported Blobstore Backup Configurations
+### <a id='supported-blobstore-backup-configurations'></a>Selective Backups Configurations for Blobstores
+When configuring your blobstore you can choose to use an external blobstore instead of the default internal blobstore. See <a href="external-blobstores.html">Backup and Restore for External Blobstores
+</a> for our list of supported external blobstores.
 
+When backing up your blobstores by default it backups droplets, buildpacks, and packages. When an external blobstore is configured, you can choose what content you want to omit from your backup using the following ops files:
+
+| Selective Backup Ops File                                                                                                                                                                                            | Backup only includes |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------|
+| <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/skip-backup-restore-droplets.yml">`skip-backup-restore-droplets.yml`</a>                           | Buildpacks, Packages |
+| <a href="https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/skip-backup-restore-droplets-and-packages.yml">`skip-backup-restore-droplets-and-packages.yml`</a> | Buildpacks           |
+
+<p class="note warning">
+When utilising selective backup ops files, you should take into a account the <a href="#selective-backup-restore-steps">extra steps needed</a> to get your applications into a running state after a restore, as they will increase your overall recovery time compared to the default configuration.
+<p>
+
+#### <a id='selective-backup-restore-steps'></a>Restoring Applications when using Selective Backups
+When using the default configuration, all applications will return to a running state after a restore.
+
+When using the `skip-backup-restore-droplets.yml` ops file, you must do the following to get your applications running after a restore:
+
+1. `cf restage` your user-pushed applications.
+1. For any applications pushed via a BOSH errand you can either manually `cf restage` them or re-run their errand.
+
+When using the `skip-backup-restore-droplets-and-packages.yml` ops file, you must do the following to get your applications running after a restore:
+
+1. `cf push` your user-pushed applications.
+1. For any applications pushed via a BOSH errand you will have to re-run their errand.
 
 ### <a id="order"></a> Apply Ops Files in the Correct Order
 When enabling backup and restore for a component of `cf-deployment` you must ensure that you have the ops file for enabling backup and restore applied after you have applied the feature. For example if you configured your `cf-deployment` to use an S3 blobstore you would need to make sure that you apply the ops files in the following order:


### PR DESCRIPTION
Add documentation how to use the ops files in cf-deployment to perform selective backups of the blobstore.

Thanks,
Jake & @gmrodgers 

story: https://www.pivotaltracker.com/story/show/162728352