### PR TITLE
Improve BBR selective backup docs

### DIFF
--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -163,7 +163,7 @@ When using the `skip-backup-restore-droplets.yml` ops file, do the following to 
 
 When using the `skip-backup-restore-droplets-and-packages.yml` ops file, do the following to get your applications running after a restore:
 
-1. For each user-pushed application, run `cf restage`.
+1. For each user-pushed application, run `cf push`.
 1. For each application pushed using a BOSH errand, re-run the BOSH errand.
 
 ### <a id="order"></a> Apply Ops Files in the Correct Order

--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -134,15 +134,15 @@ The backup and restore SDK supports the following database versions:
 | Postgres | 9.6.x   |
 
 
-### <a id='supported-blobstore-backup-configurations'></a>Selective Backup Configurations for Blobstores
+### <a id='supported-blobstore-backup-configurations'></a>Selective Backup and Restore Configurations for Blobstores
 
 When configuring your blobstore, you can choose to use an external blobstore instead
 of the default internal blobstore. For more information about supported external
 blobstores, see [Backup and Restore for External Blobstores](external-blobstores.html).
 
-When BBR backs up your blobstores, it backs up droplets, buildpacks, and packages
+When BBR backs up and restores your Cloud Foundry blobstore, it includes droplets, buildpacks, and packages
 by default. If you configure an external blobstore, you can choose to omit content
-from your backup using the following ops files:
+from your backup and restore using the following ops files:
 
 | Selective Backup Ops File                                                                                                                                                                                            | Content Included in Backup |
 |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------|
@@ -166,29 +166,31 @@ When using the `skip-backup-restore-droplets-and-packages.yml` ops file, do the 
 1. For each user-pushed application, run `cf push`.
 1. For each application pushed using a BOSH errand, re-run the BOSH errand.
 
-### <a id="order"></a> Apply Ops Files in the Correct Order
+### <a id="order"></a> Applying Ops Files in the Correct Order
 
-When enabling BBR for a `cf-deployment` component, you must apply the component
-ops file first, and then apply the ops file that enables BBR. See the following
-sections for examples of applying ops files in the correct order.
-
-**S3 Blobstore**
-
-To configure `cf-deployment` to use an S3 blobstore with BBR enabled, apply the ops files in the following order:
-
-1. `use-s3-blobstore.yml`
-1. `enable-backup-restore-s3-unversioned.yml`
+When enabling backup and restore for a `cf-deployment` component, you must apply
+the component ops files first, then `enable-backup-restore.yml`, and then any
+additional backup and restore ops files required by the components. See the
+following sections for examples of applying ops files in the correct order.
 
 **External Database**
 
-To configure `cf-deployment` to use an external database with BBR enabled, apply the ops files in the following order:
+To configure `cf-deployment` to use an external database with backup and restore enabled, apply the ops files in the following order:
 
 1. `use-external-db.yml`
 1. `enable-backup-restore.yml`
 
-<p class="note"><strong>Note</strong>: You can apply other ops files in between
-the component ops file and the BBR ops file. For example, you can apply an ops file between <code>use-s3-blobstore.yml</code> and <code>enable-backup-restore-s3-unversioned.yml</code>,
-but do not apply <code>enable-backup-restore-s3-unversioned.yml</code> before <code>use-s3-blobstore.yml</code>.<p>
+**S3-Compatible Unversioned Blobstore with Selective Backup and Restore**
+
+To configure `cf-deployment` to use an S3-compatible unversioned blobstore with selective backup and restore enabled, apply the ops files in the following order:
+
+1. `use-external-blobstore.yml`
+1. `use-s3-blobstore.yml`
+1. `enable-backup-restore.yml`
+1. `enable-backup-restore-s3-unversioned.yml`
+1. `skip-backup-and-restore-droplets-and-packages.yml`
+
+<p class="note"><strong>Note</strong>: You can apply other component ops files before the backup and restore ops files. For example, you can apply other component ops file between <code>use-s3-blobstore.yml</code> and <code>enable-backup-restore.yml</code>.<p>
 
 ## <a id='process'></a> Next Steps
 


### PR DESCRIPTION
- Fix restore apps step for skip droplets and packages  
- Document applying selective backup ops files in correct order
    - Describe selective backup and restore, not just backup.
    - Improve ops file order examples to include `enable-backup-and-restore.yml`.

Story: https://www.pivotaltracker.com/story/show/162728352

Josh and @aclevername 