### PR TITLE
Removed the mention of SSH port as it isnt configurable for BOSH

### DIFF
--- a/backup.html.md.erb
+++ b/backup.html.md.erb
@@ -72,8 +72,8 @@ through the proxy, moving backup artifacts can be significantly slower.</p>
     Where:
     * `PATH-TO-PRIVATE-KEY` is the path to the SSH private key used to connect to the BOSH Director.
     * `USER-NAME` is the SSH username of the BOSH Director.
-    * `HOST` is the address of the BOSH Director with an optional SSH port. This port defaults to the standard SSH port, `22`.
-       If the BOSH Director is public, `HOST` is a URL or public IP, such as `https://my-bosh.xxx.cf-app.com`.  Otherwise, `HOST` is the internal IP of the BOSH Director.
+    * `HOST` is the internal (or public) IP of your BOSH Director.
+       If the BOSH Director is public, this could be a public IP or a domain, such as `my-bosh.xxx.cf-app.com`.
 
     For example:
 
@@ -103,8 +103,8 @@ through the proxy, moving backup artifacts can be significantly slower.</p>
     Where:
     * `PATH-TO-PRIVATE-KEY` is the path to the SSH private key used to connect to the BOSH Director.
     * `USER-NAME` is the SSH username of the BOSH Director.
-    * `HOST` is the address of the BOSH Director with an optional SSH port. This port defaults to the standard SSH port, `22`.
-       If the BOSH Director is public, `HOST` is a URL or public IP, such as `https://my-bosh.xxx.cf-app.com`.  Otherwise, `HOST` is the internal IP of the BOSH Director.
+    * `HOST` is the internal (or public) IP of your BOSH Director.
+       If the BOSH Director is public, this could be a public IP or a domain, such as `my-bosh.xxx.cf-app.com`.
 
     For example:
 


### PR DESCRIPTION
Just fixed a few things from a recent PR!

- Removed the mention of SSH port as it isnt configurable for BOSH
- Remove protocol from host as it is incorrect
- Switch order of domain and public IP
[#164981605]

Signed-off-by: Emmanouil Kiagias <ekiagias@pivotal.io>