### PR TITLE
Expanded on use of BOSH_ALL_PROXY

### DIFF
--- a/backup.html.md.erb
+++ b/backup.html.md.erb
@@ -26,37 +26,80 @@ For general information about the jumpbox, see [Installing BOSH Backup and Resto
 
 ### <a id='ssh'></a> Connect with SSH
 
-SSH into your jumpbox. If you connect to your jumpbox with SSH, you must run the BBR commands within your jumpbox.
+To connect to your jumpbox through the CLI, perform the following command using SSH:
 
-### <a id='bosh-all-proxy'></a> Connect with BOSH_ALL_PROXY
+```
+ssh -i LOCAL-PATH-TO-JUMPBOX-PRIVATE-KEY JUMPBOX-USER@JUMPBOX-ADDRESS
+```
 
-Set and use `BOSH_ALL_PROXY`. Using `BOSH_ALL_PROXY` opens an SSH tunnel with a SOCKS5 proxy to the jumpbox. This tunnel forwards requests to the BOSH Director through the jumpbox from your local machine.
+Where:
+
+  * `LOCAL-PATH-TO-JUMPBOX-PRIVATE-KEY`  is the local path to your private key file for the jumpbox host.
+  * `JUMPBOX-USER` is your jumpbox username.
+  * `JUMPBOX-ADDRESS` is the IP address of your jumpbox.
+
+<p class="note"><strong>Note</strong>: If you connect to your jumpbox with SSH, you must run the BBR commands
+  in the following sections from within your jumpbox.
+</p>
+
+
+### <a id='bosh-all-proxy'></a> Connect with BOSH&#95;ALL&#95;PROXY
+
+Set and use `BOSH_ALL_PROXY`. Using `BOSH_ALL_PROXY` opens an SSH tunnel with SOCKS5 to the jumpbox.
+This tunnel enables you to forward requests to the BOSH Director through the jumpbox from your local machine.
+When the environment variable `BOSH_ALL_PROXY` is set, the BBR cli will always utilise its value to forward
+requests to the BOSH Director.
 
 Use one of the following methods to create the tunnel:
-
-* **Tunnel created by BOSH CLI**: To provide the BOSH CLI with the SSH credentials it needs to create the tunnel, run the following command:
-
-    ```
-	 export BOSH_ALL_PROXY=ssh+socks5://jumpbox@jumpbox-ip:12345?private_key=jumpbox.key
-	 ```
 
 * **Tunnel established separately**:
 
   1. To establish the tunnel and make it available on a local port, run the following command:
 
     ```
-    ssh -4 -D 12345 -fNC jumpbox@jumpbox-ip -i jumpbox.key
+    ssh -4 -D SOCKS-PORT -fNC JUMPBOX@JUMPBOX-IP -i JUMPBOX-KEY-FILE -o ServerAliveInterval=60
     ```
-	
-  1. To provide the BOSH CLI with access to the tunnel through use of the `BOSH_ALL_PROXY` environment variable, run the following command:
+
+    Where:
+    * `SOCKS-PORT` is the local SOCKS port.
+    * `JUMPBOX` is the name of your jumpbox.
+    * `JUMPBOX-IP` is the IP address of the jumpbox.
+    * `JUMPBOX-KEY-FILE` is the local SSH private key for accessing the jumpbox.
+
+  1. To provide the BOSH CLI with access to the tunnel through use of the `BOSH_ALL_PROXY` environment variable,
+  run the following command:
 
     ```
-    export BOSH_ALL_PROXY=socks5://localhost:12345
+    export BOSH_ALL_PROXY=socks5://localhost:SOCKS-PORT
     ```
+
+* **Tunnel created by BOSH CLI**: To provide the BOSH CLI with the SSH credentials it needs to create the
+tunnel, run the following command:
+
+    ```
+    export BOSH_ALL_PROXY=ssh+socks5://JUMPBOX@JUMPBOX-IP:SOCKS-PORT?private_key=JUMPBOX-KEY-FILE
+    ```
+
+    Where:
+    * `JUMPBOX` is the name of your jumpbox.
+    * `JUMPBOX-IP` is the IP address of the jumpbox.
+    * `SOCKS-PORT` is the local SOCKS port.
+    * `JUMPBOX-KEY-FILE` is the local SSH private key for accessing the jumpbox.
+
+
+<p class="note"><strong>Note</strong>: Ensure the SOCKS port is not already in use by a different tunnel/process.
+</p>
 
 <p class="note"><strong>Note</strong>: Using <code>BOSH_ALL_PROXY</code> can result in longer
 backup and restore times due to network performance degradation. Because all operations must pass
-through the proxy, moving backup artifacts can be significantly slower.</p>
+through the proxy, moving backup artifacts can be significantly slower.
+</p>
+
+<div class="note warning"><strong>Warning:</strong>
+Prior to version <a href="https://github.com/cloudfoundry-incubator/bosh-backup-and-restore/releases/tag/v1.5.1">v1.5.1</a>
+of the BBR cli, the tunnel created by the BOSH cli did not include the necessary <code>ServerAliveInterval</code> flag.
+This may result in your SSH connection timing out when transferring large artifacts.
+</div>
 
 ## <a id='back-up-director'></a> Back up a BOSH Director
 


### PR DESCRIPTION
Hey folks

We have added some more detail to the usage of BOSH_ALL_PROXY env var with BBR, specifically:
- added ServerAliveInterval flag in manual ssh connection example
- version warning for potential timeouts for bbr <v1.5.1
- rearranged order of tunnel creation methods to subtly nudge users to
use the manual example
- add examples

[#165377971]

Thanks,
Glen & @terminatingcode 