### PR TITLE
Improve bbr sdk maintainability

### DIFF
--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -122,17 +122,7 @@ BBR can communicate with external blobstores and databases over TLS if they are 
 ### <a id='supported-external-databases'></a>Supported External Databases
 
 Cloud Foundry components use the backup and restore SDK to interface with databases for backup and restore.
-The backup and restore SDK supports the following database versions:
-
-| Name     | Version |
-|:---------|:--------|
-| MariaDB  | 10.1.x  |
-| MySQL    | 5.5.x   |
-| MySQL    | 5.6.x   |
-| MySQL    | 5.7.x   |
-| Postgres | 9.4.x   |
-| Postgres | 9.6.x   |
-
+For supported databases and versions, please see [backup and restore SDK github repo](https://github.com/cloudfoundry-incubator/backup-and-restore-sdk-release#database-backup-and-restore).
 
 ### <a id='supported-blobstore-backup-configurations'></a>Selective Backup and Restore Configurations for Blobstores
 

--- a/cf-backup.html.md.erb
+++ b/cf-backup.html.md.erb
@@ -131,7 +131,7 @@ of the default internal blobstore. For more information about supported external
 blobstores, see [Backup and Restore for External Blobstores](external-blobstores.html).
 
 When BBR backs up and restores your Cloud Foundry blobstore, it includes droplets, buildpacks, and packages
-by default. If you configure an external blobstore, you can choose to omit content
+by default. For your blobstore, you can choose to omit content
 from your backup and restore using the following ops files:
 
 | Selective Backup Ops File                                                                                                                                                                                            | Content Included in Backup |


### PR DESCRIPTION
Hello folks, this is another PR to reduce the duplication in our docs. We are now referring to the github readme instead of having a table.

We also updated the selective backups section to not exclude internal blobstores.