### PR TITLE
Fix off-by-one year in release notes

### DIFF
--- a/bbr-rn.html.md.erb
+++ b/bbr-rn.html.md.erb
@@ -20,7 +20,7 @@ owner: Release Engineering
 
 ### <a id='1-5-1'></a> v1.5.1
 
-**Release Date**: May 3, 2018
+**Release Date**: May 3, 2019
 
 #### Features
 


### PR DESCRIPTION
The release notes list 1.5.1's release date as 2018, where (I'm guessing, but I think I'm right!) it should be 2019.

This PR fixes that.