### PR TITLE
Add backup and restore recommendations

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -47,6 +47,14 @@ This approach has the following advantages:
 1. **restore**: The restore script restores the release.
 1. **post-restore-unlock**: The post-restore-unlock script unlocks the job after the restore is complete.
 
+## <a id='recs'></a> Recommendations
+
+* Back up frequently, especially before upgrading any deployment.
+
+* For BOSH v270.0 and above, you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
+
+<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed <strong>and</strong> no service instances have been created, the releases needed to create a service instance will be categorised as unused and removed.</p>
+
 ## <a id='workflow'></a>What happens when you run a BBR backup?
 
 *Prerequisite:* The operator has [installed BBR](installing.html)

--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -14,6 +14,14 @@ For more information about installing and using BBR, see the [Installing BOSH Ba
 
 For more information about backing up and restoring cf-deployment with BBR, see [Configuring Cloud Foundry for BOSH Backup and Restore](cf-backup.html).
 
+## <a id='recs'></a> Recommendations
+
+* Back up frequently, especially before upgrading any deployment.
+
+* For BOSH v270.0 and above, you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
+
+<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed <strong>and</strong> no service instances have been created, the releases needed to create a service instance will be categorised as unused and removed.</p>
+
 ## <a id='supported'></a>Supported Components
 
 BBR is a binary that can back up and restore BOSH deployments and BOSH Directors. BBR requires that the backup targets supply scripts that implement the backup and restore functions.
@@ -46,14 +54,6 @@ This approach has the following advantages:
 1. **pre-restore-lock**: The pre-restore-lock script locks the job so the restore is consistent across the cluster.
 1. **restore**: The restore script restores the release.
 1. **post-restore-unlock**: The post-restore-unlock script unlocks the job after the restore is complete.
-
-## <a id='recs'></a> Recommendations
-
-* Back up frequently, especially before upgrading any deployment.
-
-* For BOSH v270.0 and above, you can prune the BOSH blobstore by running `bosh clean-up --all` prior to running a backup of the BOSH director. This will remove all unused resources including packages compiled against older stemcell versions. This will result in a smaller, faster backup of the BOSH director if a lot of unused resources have accumulated over time. For more information see [Clean-Up](https://bosh.io/docs/cli-v2/#clean-up).
-
-<p class="note"><strong>Note:</strong>The command `bosh clean-up --all` is a destructive operation and can remove resources that are unused but needed. For example, if an On-Demand Service Broker is deployed <strong>and</strong> no service instances have been created, the releases needed to create a service instance will be categorised as unused and removed.</p>
 
 ## <a id='workflow'></a>What happens when you run a BBR backup?
 


### PR DESCRIPTION
This informs operators that they can run a clean-up operation prior to performing a BOSH director backup. It is accompanied by a warning note that this operation is destructive and to be aware of the potential damage.

Story [here](https://www.pivotaltracker.com/story/show/166407001)