### PR TITLE
Add correct BOSH_ALL_PROXY private key param name

### DIFF
--- a/backup.html.md.erb
+++ b/backup.html.md.erb
@@ -82,7 +82,7 @@ To connect with `BOSH_ALL_PROXY`, follow one of the below procedures:
     running:
 
     ```
-    export BOSH_ALL_PROXY=ssh+socks5://JUMPBOX-USERNAME@JUMPBOX-ADDRESS:SOCKS-PORT?private_key=JUMPBOX-KEY-FILE
+    export BOSH_ALL_PROXY=ssh+socks5://JUMPBOX-USERNAME@JUMPBOX-ADDRESS:SOCKS-PORT?private-key=JUMPBOX-KEY-FILE
     ```
     Where:
     * `JUMPBOX-USERNAME` is your jumpbox username.


### PR DESCRIPTION
Changed the private-key param name to avoid this error:

```
Retry: Get "https://192.168.1.11:25555/info": Parsing BOSH_ALL_PROXY query params: Required query param 'private-key' not found
```